### PR TITLE
CHORE: Update Nuxt config for compatibility with Nitro deploy.

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -38,6 +38,12 @@ export default defineNuxtConfig({
         }
       }
     }
+  },
+
+  nitro: {
+    output: {
+      dir: "dist"
+    }
   }
 
 })


### PR DESCRIPTION
# Changes

* Nitro deployment instructions specify that the build (publish) directory should be named "dist" for all the serverless config on Netlify to work automatically.